### PR TITLE
Remove newline from echo to fix clipboard pasting X11

### DIFF
--- a/record_audio_output
+++ b/record_audio_output
@@ -20,5 +20,5 @@ else
 	parec -d $targetSink --volume=65536 | lame -r -V7 - $filename
 
 	# Copy the file to the clipboard
-	echo "file://${filename}"|xclip -i -sel c -t text/uri-list
+	echo -n "file://${filename}"|xclip -i -sel c -t text/uri-list
 fi

--- a/record_audio_output_pw
+++ b/record_audio_output_pw
@@ -15,7 +15,7 @@ else
   pw-record -P '{ stream.capture.sink=true }' - | lame -r -s 48 -m s -V7 - $filename
 
   # Copy the file to the clipboard in X11
-  echo "file://${filename}"|xclip -i -sel c -t text/uri-list
+  echo -n "file://${filename}"|xclip -i -sel c -t text/uri-list
 
   # Copy the file to the clipboard in Wayland
   # wl-copy -t text/uri-list <<< "file://${filename}" --foreground


### PR DESCRIPTION
Hi there!

Thanks for making these scripts, they have been helpful to get audio clips for language learning. I was having an issue pasting the file uri into programs since the `echo` command outputs a newline, so I added the `-n` option to both scripts to fix them for X11.